### PR TITLE
Update LLVM in Ubuntu 16.04 script, other fixes

### DIFF
--- a/scripts/mapd-deps-ubuntu1604.sh
+++ b/scripts/mapd-deps-ubuntu1604.sh
@@ -66,7 +66,8 @@ sudo apt install -y \
     flex-old \
     jq \
     python-yaml \
-    libxmlsec1-dev
+    libxmlsec1-dev \
+    libtool
 
 # Install gcc6
 add-apt-repository ppa:ubuntu-toolchain-r/test -y
@@ -171,6 +172,9 @@ cmake \
 make -j $(nproc)
 make install
 popd
+
+# proj.4
+download_make_install ${HTTP_DEPS}/proj-5.2.0.tar.gz
 
 # gdal
 download_make_install ${HTTP_DEPS}/gdal-2.3.2.tar.xz "" "--without-geos --with-libkml=$PREFIX --with-proj=$PREFIX"add-apt-repository -y ppa:ubuntugis/ppa

--- a/scripts/mapd-deps-ubuntu1604.sh
+++ b/scripts/mapd-deps-ubuntu1604.sh
@@ -177,7 +177,7 @@ popd
 download_make_install ${HTTP_DEPS}/proj-5.2.0.tar.gz
 
 # gdal
-download_make_install ${HTTP_DEPS}/gdal-2.3.2.tar.xz "" "--without-geos --with-libkml=$PREFIX --with-proj=$PREFIX"add-apt-repository -y ppa:ubuntugis/ppa
+download_make_install ${HTTP_DEPS}/gdal-2.3.2.tar.xz "" "--without-geos --with-libkml=$PREFIX --with-proj=$PREFIX"
 
 # OpenSAML
 

--- a/scripts/mapd-deps-ubuntu1604.sh
+++ b/scripts/mapd-deps-ubuntu1604.sh
@@ -11,6 +11,12 @@ source $SCRIPTS_DIR/common-functions.sh
 sudo mkdir -p $PREFIX
 sudo chown -R $(id -u) $PREFIX
 
+apt install wget -y
+
+# add llvm 6 repository
+add-apt-repository -y 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main'
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+
 sudo apt update
 sudo apt install -y \
     build-essential \

--- a/scripts/mapd-deps-ubuntu1604.sh
+++ b/scripts/mapd-deps-ubuntu1604.sh
@@ -46,7 +46,6 @@ sudo apt install -y \
     google-perftools \
     libdouble-conversion-dev \
     libevent-dev \
-    libgdal-dev \
     libgflags-dev \
     libgoogle-perftools-dev \
     libiberty-dev \
@@ -172,6 +171,9 @@ cmake \
 make -j $(nproc)
 make install
 popd
+
+# gdal
+download_make_install ${HTTP_DEPS}/gdal-2.3.2.tar.xz "" "--without-geos --with-libkml=$PREFIX --with-proj=$PREFIX"add-apt-repository -y ppa:ubuntugis/ppa
 
 # OpenSAML
 

--- a/scripts/mapd-deps-ubuntu1604.sh
+++ b/scripts/mapd-deps-ubuntu1604.sh
@@ -13,8 +13,8 @@ sudo chown -R $(id -u) $PREFIX
 
 apt install wget -y
 
-# add llvm 6 repository
-add-apt-repository -y 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main'
+# add llvm repository
+add-apt-repository -y 'deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial main'
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 
 sudo apt update

--- a/scripts/mapd-deps-ubuntu1604.sh
+++ b/scripts/mapd-deps-ubuntu1604.sh
@@ -67,7 +67,8 @@ sudo apt install -y \
     jq \
     python-yaml \
     libxmlsec1-dev \
-    libtool
+    libtool \
+    libpng12-dev
 
 # Install gcc6
 add-apt-repository ppa:ubuntu-toolchain-r/test -y


### PR DESCRIPTION
Fixes #339

Adds apt repository to get a newer version of LLVM, ports over some additional changes for GDAL and others to get the Ubuntu 16.04 script back in working order. 