### PR TITLE
none encding string sort error!!!!

### DIFF
--- a/QueryEngine/ResultSetIteration.cpp
+++ b/QueryEngine/ResultSetIteration.cpp
@@ -658,7 +658,7 @@ int64_t ResultSet::lazyReadInt(const int64_t ival,
         bool is_end{false};
         ChunkIter_get_nth(
             reinterpret_cast<ChunkIter*>(const_cast<int8_t*>(frag_col_buffer)),
-            storage_lookup_result.fixedup_entry_idx,
+            ival_copy,
             false,
             &vd,
             &is_end);


### PR DESCRIPTION
when use kENCODING_NONE string sort, result is error,i find the promble is that system get data use ResultSet index. we should use actually line number(ival_copy).