### PR TITLE
Added possibility to compile jit code with llvm's optimization levels O1-O3

### DIFF
--- a/MapDServer.cpp
+++ b/MapDServer.cpp
@@ -282,6 +282,8 @@ class MapDProgramOptions {
   bool enable_dynamic_watchdog = false;
   unsigned dynamic_watchdog_time_limit = 10000;
 
+  unsigned opt_level = 0;
+
   /**
    * Can be used to override the number of gpus detected on the system
    * -1 means do not override
@@ -612,6 +614,9 @@ void MapDProgramOptions::fillAdvancedOptions() {
           ->default_value(intel_jit_profile)
           ->implicit_value(true),
       "Enable runtime support for the JIT code profiling using Intel VTune.");
+  developer_desc.add_options()("opt-level",
+                               po::value<unsigned>(&opt_level)->default_value(opt_level),
+                               "Set LLVM opt level IR optimization");
   developer_desc.add_options()(
       "skip-intermediate-count",
       po::value<bool>(&g_skip_intermediate_count)
@@ -1103,6 +1108,7 @@ int startMapdServer(MapDProgramOptions& prog_config_opts) {
                                      prog_config_opts.allow_multifrag,
                                      prog_config_opts.jit_debug,
                                      prog_config_opts.intel_jit_profile,
+                                     prog_config_opts.opt_level,
                                      prog_config_opts.read_only,
                                      prog_config_opts.allow_loop_joins,
                                      prog_config_opts.enable_rendering,

--- a/QueryEngine/CompilationOptions.h
+++ b/QueryEngine/CompilationOptions.h
@@ -19,7 +19,7 @@
 
 enum class ExecutorDeviceType { CPU, GPU };
 
-enum class ExecutorOptLevel { Default, LoopStrengthReduction, ReductionJIT };
+enum class ExecutorOptLevel { Default, O1, O2, O3, LoopStrengthReduction, ReductionJIT };
 
 enum class ExecutorExplainType { Default, Optimized };
 

--- a/QueryEngine/CompilationOptions.h
+++ b/QueryEngine/CompilationOptions.h
@@ -19,7 +19,14 @@
 
 enum class ExecutorDeviceType { CPU, GPU };
 
-enum class ExecutorOptLevel { Default, O1, O2, O3, LoopStrengthReduction, ReductionJIT };
+enum class ExecutorOptLevel {
+  Default,
+  O1 = 1,
+  O2 = 2,
+  O3 = 3,
+  LoopStrengthReduction,
+  ReductionJIT
+};
 
 enum class ExecutorExplainType { Default, Optimized };
 

--- a/ThriftHandler/MapDHandler.cpp
+++ b/ThriftHandler/MapDHandler.cpp
@@ -140,6 +140,7 @@ MapDHandler::MapDHandler(const std::vector<LeafHostInfo>& db_leaves,
                          const bool allow_multifrag,
                          const bool jit_debug,
                          const bool intel_jit_profile,
+                         const unsigned opt_level,
                          const bool read_only,
                          const bool allow_loop_joins,
                          const bool enable_rendering,
@@ -164,6 +165,7 @@ MapDHandler::MapDHandler(const std::vector<LeafHostInfo>& db_leaves,
     , session_id_dist_(0, INT32_MAX)
     , jit_debug_(jit_debug)
     , intel_jit_profile_(intel_jit_profile)
+    , opt_level_((ExecutorOptLevel)opt_level)
     , allow_multifrag_(allow_multifrag)
     , read_only_(read_only)
     , allow_loop_joins_(allow_loop_joins)
@@ -4364,7 +4366,7 @@ std::vector<PushedDownFilterInfo> MapDHandler::execute_rel_alg(
   const auto& cat = query_state_proxy.getQueryState().getConstSessionInfo()->getCatalog();
   CompilationOptions co = {executor_device_type,
                            true,
-                           ExecutorOptLevel::Default,
+                           opt_level_,
                            g_enable_dynamic_watchdog,
                            explain_optimized_ir ? ExecutorExplainType::Optimized
                                                 : ExecutorExplainType::Default,
@@ -4426,7 +4428,7 @@ void MapDHandler::execute_rel_alg_df(TDataFrame& _return,
         session_info.get_executor_device_type() == ExecutorDeviceType::GPU);
   CompilationOptions co = {session_info.get_executor_device_type(),
                            true,
-                           ExecutorOptLevel::Default,
+                           opt_level_,
                            g_enable_dynamic_watchdog,
                            ExecutorExplainType::Default,
                            intel_jit_profile_};

--- a/ThriftHandler/MapDHandler.h
+++ b/ThriftHandler/MapDHandler.h
@@ -127,6 +127,7 @@ class MapDHandler : public MapDIf {
               const bool allow_multifrag,
               const bool jit_debug,
               const bool intel_jit_profile,
+              const unsigned opt_level,
               const bool read_only,
               const bool allow_loop_joins,
               const bool enable_rendering,
@@ -448,6 +449,7 @@ class MapDHandler : public MapDIf {
   std::uniform_int_distribution<int64_t> session_id_dist_;
   const bool jit_debug_;
   const bool intel_jit_profile_;
+  const ExecutorOptLevel opt_level_;
   bool allow_multifrag_;
   const bool read_only_;
   const bool allow_loop_joins_;


### PR DESCRIPTION
This is an attempt to allow choosing llvm's optimization level for compiling JIT code. In some case this could give good performance boost (20-30% on some tpc-h queries)

Targeting #392  