### PR TITLE
avoid big and sparse perfect hash tables

### DIFF
--- a/QueryEngine/JoinHashTable/PerfectJoinHashTable.cpp
+++ b/QueryEngine/JoinHashTable/PerfectJoinHashTable.cpp
@@ -203,6 +203,17 @@ std::shared_ptr<PerfectJoinHashTable> PerfectJoinHashTable::getInstance(
     throw TooManyHashEntries();
   }
 
+  // We don't want to build huge and very sparse tables
+  // to consume lots of memory.
+  if (bucketized_entry_count > 1000000) {
+    const auto& query_info =
+        get_inner_query_info(inner_col->get_table_id(), query_infos).info;
+    if (query_info.getNumTuplesUpperBound() * 100 <
+        huge_join_hash_min_load_ * bucketized_entry_count) {
+      throw TooManyHashEntries();
+    }
+  }
+
   if (qual_bin_oper->get_optype() == kBW_EQ &&
       col_range.getIntMax() >= std::numeric_limits<int64_t>::max()) {
     throw HashJoinFail("Cannot translate null value for kBW_EQ");

--- a/QueryEngine/JoinHashTable/PerfectJoinHashTable.h
+++ b/QueryEngine/JoinHashTable/PerfectJoinHashTable.h
@@ -107,6 +107,11 @@ class PerfectJoinHashTable : public HashJoin {
   virtual ~PerfectJoinHashTable() {}
 
  private:
+  // We don't want to create JoinHashTable for big ranges
+  // with small number of valid entries. Therefore we
+  // define the minimal load level (in percent).
+  static constexpr size_t huge_join_hash_min_load_ = 10;
+
   // Equijoin API
   ColumnsForDevice fetchColumnsForDevice(
       const std::vector<Fragmenter_Namespace::FragmentInfo>& fragments,


### PR DESCRIPTION
Currently we can get huge perfect hash tables with just a few valid elements. We found it especially hurtful for window functions where each empty entry means a partition requiring some space in a result set, initialization etc.
The proposal is to fall back to baseline hash in such cases.