### PR TITLE
cmake: use find_program, handle std args for bison++, flex++

### DIFF
--- a/Parser/CMakeLists.txt
+++ b/Parser/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(
     OUTPUT
       ${BisonppOutput}
       ${CMAKE_CURRENT_BINARY_DIR}/parser.h
-    COMMAND ${BISONPP_EXECUTABLE}
+    COMMAND ${Bisonpp_EXECUTABLE}
     -d
     -h${CMAKE_CURRENT_BINARY_DIR}/parser.h
         -o${BisonppOutput}
@@ -22,7 +22,7 @@ set(FlexppOutput ${CMAKE_CURRENT_BINARY_DIR}/Scanner_with_register.cpp)
 
 add_custom_command(
     OUTPUT ${FlexppOutput}
-    COMMAND ${FLEXPP_EXECUTABLE}
+    COMMAND ${Flexpp_EXECUTABLE}
         -d
         -i
         -o${FlexppOutput}
@@ -31,7 +31,7 @@ add_custom_command(
     COMMENT "Generating Scanner.cpp"
 )
 
-# C++17 removes the 'register' keyword and it is no longer allowed to 
+# C++17 removes the 'register' keyword and it is no longer allowed to
 # suppress the warning, so patch the generated scanner and parser files
 # to remove the register keyword, and also patch embedded filename strings
 # so they match the final file
@@ -40,9 +40,9 @@ set(ScannerPatched ${CMAKE_CURRENT_BINARY_DIR}/Scanner.cpp)
 
 add_custom_command(
     OUTPUT ${ParserPatched}
-    COMMAND sed 
-        -e "s/register //g" 
-        -e "s/Parser_with_register/Parser/g" 
+    COMMAND sed
+        -e "s/register //g"
+        -e "s/Parser_with_register/Parser/g"
         ${BisonppOutput} > ${ParserPatched}
     DEPENDS ${BisonppOutput}
     COMMENT "Patching Parser.cpp to remove register keyword"
@@ -50,16 +50,16 @@ add_custom_command(
 
 add_custom_command(
     OUTPUT ${ScannerPatched}
-    COMMAND sed 
-      -e "s/register //g" 
-      -e "s/Scanner_with_register/Scanner/g" 
+    COMMAND sed
+      -e "s/register //g"
+      -e "s/Scanner_with_register/Scanner/g"
       ${FlexppOutput} > ${ScannerPatched}
     DEPENDS ${FlexppOutput}
     COMMENT "Patching Scanner.cpp to remove register keyword"
 )
 
 add_custom_target(ParserFiles DEPENDS ${BisonppOutput})
-add_custom_target(ScannerFiles DEPENDS ${FlexppOutput})	
+add_custom_target(ScannerFiles DEPENDS ${FlexppOutput})
 
 add_custom_target(PatchParser DEPENDS ${ParserPatched})
 add_custom_target(PatchScanner DEPENDS ${ScannerPatched})

--- a/cmake/Modules/FindBisonpp.cmake
+++ b/cmake/Modules/FindBisonpp.cmake
@@ -1,73 +1,30 @@
-# - Look for GNU Bison++, the parser generator
-# Based off a news post from Andy Cedilnik at Kitware
-# Defines the following:
-#  BISONPP_EXECUTABLE - path to the bison executable
-#  BISONPP_FILE - parse a file with bison
-#  BISONPP_PREFIX_OUTPUTS - Set to true to make BISON_FILE produce prefixed
-#                         symbols in the generated output based on filename.
-#                         So for ${filename}.y, you'll get ${filename}parse(), etc.
-#                         instead of yyparse().
-#  BISONPP_GENERATE_DEFINES - Set to true to make BISON_FILE output the matching
-#                           .h file for a .c file. You want this if you're using
-#                           flex.
+#.rst:
+# FindBisonpp.cmake
+# -------------
+#
+# Find a Bison++ installation.
+#
+# This module finds if Bisonpp is installed and selects a default
+# configuration to use.
+#
+# find_package(Bisonpp ...)
+#
+#
+# The following are set after the configuration is done:
+#
+# ::
+#
+#   Bisonpp_FOUND            - Set to TRUE if Bisonpp was found.
+#   Bisonpp_EXECUTABLE       - Path to the Bisonpp executable.
 
-#Modified by Markus for bison++
+find_program(Bisonpp_EXECUTABLE
+  NAMES bison++
+  PATHS
+  /usr/bin
+  /usr/local/bin
+  /usr/local/homebrew/bin
+  /opt/local/bin)
 
-IF(NOT DEFINED BISONPP_PREFIX_OUTPUTS)
- SET(BISONPP_PREFIX_OUTPUTS FALSE)
-ENDIF(NOT DEFINED BISONPP_PREFIX_OUTPUTS)
-
-IF(NOT DEFINED BISONPP_GENERATE_DEFINES)
- SET(BISONPP_GENERATE_DEFINES FALSE)
-ENDIF(NOT DEFINED BISONPP_GENERATE_DEFINES)
-
-IF(NOT BISONPP_EXECUTABLE)
- MESSAGE(STATUS "Looking for bison++")
- FIND_PROGRAM(BISONPP_EXECUTABLE bison++)
- IF(BISONPP_EXECUTABLE)
-   MESSAGE(STATUS "Looking for bison++ -- ${BISONPP_EXECUTABLE}")
- ENDIF(BISONPP_EXECUTABLE)
-ENDIF(NOT BISONPP_EXECUTABLE)
-
-IF(BISONPP_EXECUTABLE)
- MACRO(BISONPP_FILE FILENAME)
-   GET_FILENAME_COMPONENT(PATH "${FILENAME}" PATH)
-   IF("${PATH}" STREQUAL "")
-     SET(PATH_OPT "")
-   ELSE("${PATH}" STREQUAL "")
-     SET(PATH_OPT "/${PATH}")
-   ENDIF("${PATH}" STREQUAL "")
-   GET_FILENAME_COMPONENT(HEAD "${FILENAME}" NAME_WE)
-   IF(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}${PATH_OPT}")
-     FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}${PATH_OPT}")
-   ENDIF(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}${PATH_OPT}")
-   IF(BISONPP_PREFIX_OUTPUTS)
-     SET(PREFIX "${HEAD}")
-   ELSE(BISONPP_PREFIX_OUTPUTS)
-     SET(PREFIX "yy")
-   ENDIF(BISONPP_PREFIX_OUTPUTS)
-   SET(OUTFILE "${CMAKE_CURRENT_BINARY_DIR}${PATH_OPT}/${HEAD}.tab.cpp")
-   IF(BISONPP_GENERATE_DEFINES)
-     SET(HEADER "${CMAKE_CURRENT_BINARY_DIR}${PATH_OPT}/${HEAD}.tab.h")
-     ADD_CUSTOM_COMMAND(
-       OUTPUT "${OUTFILE}" "${HEADER}"
-       COMMAND "${BISONPP_EXECUTABLE}"
-       ARGS "--name-prefix=${PREFIX}"
-       "--defines"
-       "--output-file=${OUTFILE}"
-       "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}"
-       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}")
-     SET_SOURCE_FILES_PROPERTIES("${OUTFILE}" "${HEADER}" PROPERTIES GENERATED TRUE)
-     SET_SOURCE_FILES_PROPERTIES("${HEADER}" PROPERTIES HEADER_FILE_ONLY TRUE)
-   ELSE(BISONPP_GENERATE_DEFINES)
-     ADD_CUSTOM_COMMAND(
-       OUTPUT "${OUTFILE}"
-       COMMAND "${BISONPP_EXECUTABLE}"
-       ARGS "--name-prefix=${PREFIX}"
-       "--output-file=${OUTFILE}"
-       "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}"
-       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}")
-     SET_SOURCE_FILES_PROPERTIES("${OUTFILE}" PROPERTIES GENERATED TRUE)
-   ENDIF(BISONPP_GENERATE_DEFINES)
- ENDMACRO(BISONPP_FILE) 
-ENDIF(BISONPP_EXECUTABLE)
+# Set standard CMake FindPackage variables if found.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Bisonpp REQUIRED_VARS Bisonpp_EXECUTABLE)

--- a/cmake/Modules/FindFlexpp.cmake
+++ b/cmake/Modules/FindFlexpp.cmake
@@ -1,73 +1,30 @@
-# - Look for GNU Flex++, the scanner generator
-# Based off a news post from Andy Cedilnik at Kitware
-# Defines the following:
-#  FLEXPP_EXECUTABLE - path to the bison executable
-#  FLEXPP_FILE - parse a file with bison
-#  FLEXPP_PREFIX_OUTPUTS - Set to true to make BISON_FILE produce prefixed
-#                         symbols in the generated output based on filename.
-#                         So for ${filename}.y, you'll get ${filename}parse(), etc.
-#                         instead of yyparse().
-#  FLEXPP_GENERATE_DEFINES - Set to true to make BISON_FILE output the matching
-#                           .h file for a .c file. You want this if you're using
-#                           flex.
+#.rst:
+# FindFlexpp.cmake
+# -------------
+#
+# Find a Flex++ installation.
+#
+# This module finds if Flexpp is installed and selects a default
+# configuration to use.
+#
+# find_package(Flexpp ...)
+#
+#
+# The following are set after the configuration is done:
+#
+# ::
+#
+#   Flexpp_FOUND            - Set to TRUE if Flexpp was found.
+#   Flexpp_EXECUTABLE       - Path to the Flexpp executable.
 
-#Modified by Markus for flex++
+find_program(Flexpp_EXECUTABLE
+  NAMES flex++
+  PATHS
+  /usr/bin
+  /usr/local/bin
+  /usr/local/homebrew/bin
+  /opt/local/bin)
 
-IF(NOT DEFINED FLEXPP_PREFIX_OUTPUTS)
- SET(FLEXPP_PREFIX_OUTPUTS FALSE)
-ENDIF(NOT DEFINED FLEXPP_PREFIX_OUTPUTS)
-
-IF(NOT DEFINED FLEXPP_GENERATE_DEFINES)
- SET(FLEXPP_GENERATE_DEFINES FALSE)
-ENDIF(NOT DEFINED FLEXPP_GENERATE_DEFINES)
-
-IF(NOT FLEXPP_EXECUTABLE)
- MESSAGE(STATUS "Looking for flex++")
- FIND_PROGRAM(FLEXPP_EXECUTABLE flex++)
- IF(FLEXPP_EXECUTABLE)
-   MESSAGE(STATUS "Looking for flex++ -- ${FLEXPP_EXECUTABLE}")
- ENDIF(FLEXPP_EXECUTABLE)
-ENDIF(NOT FLEXPP_EXECUTABLE)
-
-IF(FLEXPP_EXECUTABLE)
- MACRO(FLEXPP_FILE FILENAME)
-   GET_FILENAME_COMPONENT(PATH "${FILENAME}" PATH)
-   IF("${PATH}" STREQUAL "")
-     SET(PATH_OPT "")
-   ELSE("${PATH}" STREQUAL "")
-     SET(PATH_OPT "/${PATH}")
-   ENDIF("${PATH}" STREQUAL "")
-   GET_FILENAME_COMPONENT(HEAD "${FILENAME}" NAME_WE)
-   IF(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}${PATH_OPT}")
-     FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}${PATH_OPT}")
-   ENDIF(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}${PATH_OPT}")
-   IF(FLEXPP_PREFIX_OUTPUTS)
-     SET(PREFIX "${HEAD}")
-   ELSE(FLEXPP_PREFIX_OUTPUTS)
-     SET(PREFIX "yy")
-   ENDIF(FLEXPP_PREFIX_OUTPUTS)
-   SET(OUTFILE "${CMAKE_CURRENT_BINARY_DIR}${PATH_OPT}/${HEAD}.tab.cpp")
-   IF(FLEXPP_GENERATE_DEFINES)
-     SET(HEADER "${CMAKE_CURRENT_BINARY_DIR}${PATH_OPT}/${HEAD}.tab.h")
-     ADD_CUSTOM_COMMAND(
-       OUTPUT "${OUTFILE}" "${HEADER}"
-       COMMAND "${FLEXPP_EXECUTABLE}"
-       ARGS "--name-prefix=${PREFIX}"
-       "--defines"
-       "--output-file=${OUTFILE}"
-       "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}"
-       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}")
-     SET_SOURCE_FILES_PROPERTIES("${OUTFILE}" "${HEADER}" PROPERTIES GENERATED TRUE)
-     SET_SOURCE_FILES_PROPERTIES("${HEADER}" PROPERTIES HEADER_FILE_ONLY TRUE)
-   ELSE(FLEXPP_GENERATE_DEFINES)
-     ADD_CUSTOM_COMMAND(
-       OUTPUT "${OUTFILE}"
-       COMMAND "${FLEXPP_EXECUTABLE}"
-       ARGS "--name-prefix=${PREFIX}"
-       "--output-file=${OUTFILE}"
-       "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}"
-       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}")
-     SET_SOURCE_FILES_PROPERTIES("${OUTFILE}" PROPERTIES GENERATED TRUE)
-   ENDIF(FLEXPP_GENERATE_DEFINES)
- ENDMACRO(FLEXPP_FILE) 
-ENDIF(FLEXPP_EXECUTABLE)
+# Set standard CMake FindPackage variables if found.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Flexpp REQUIRED_VARS Flexpp_EXECUTABLE)


### PR DESCRIPTION
This forces cmake to actually error out on the configure stage if
`bison++` or `flex++` are not found. Previously it would simply sub in
`BISONPP_EXECUTABLE_NOTFOUND` for the path.

Resolves #590