### PR TITLE
Enable ITT notify profiling API for queries and keywords

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,21 @@ include_directories(${CMAKE_SOURCE_DIR}
 
 ## Dependencies
 
+# Intel ITT notify
+option(ENABLE_ITT "Enable Intel ittnotify for VTune and Advisor" OFF)
+if(ENABLE_ITT)
+  find_package(ITTnotify REQUIRED)
+  add_definitions(-DENABLE_ITT)
+  include_directories("${ITTnotify_INCLUDE_DIRS}/")
+  set(VT_LIBS ${ITTnotify_LIBRARIES} dl)
+  option(ENABLE_INTEL_JIT_LISTENER "Enable Intel Vtune JIT Listener" ON)
+else()
+  option(ENABLE_INTEL_JIT_LISTENER "Enable Intel Vtune JIT Listener" OFF)
+endif(ENABLE_ITT)
+if(ENABLE_INTEL_JIT_LISTENER)
+  add_definitions(-DENABLE_INTEL_JIT_LISTENER)
+endif()
+
 # LLVM
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/llvm")
@@ -325,7 +340,6 @@ find_library(LLVM_LIB LLVM)
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" OR NOT LLVM_LIB)
   set(LLVM_COMPONENTS support mcjit core irreader option)
 
-  option(ENABLE_INTEL_JIT_LISTENER "Enable Intel Vtune JIT Listener" OFF)
   if(ENABLE_INTEL_JIT_LISTENER)
     list(APPEND LLVM_COMPONENTS inteljitevents)
   endif()
@@ -729,7 +743,7 @@ add_custom_target(rerun_cmake ALL
   )
 add_dependencies(omnisci_server rerun_cmake)
 
-target_link_libraries(omnisci_server mapd_thrift thrift_handler ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${PROFILER_LIBS} ${ZLIB_LIBRARIES} ${LOCALE_LINK_FLAG})
+target_link_libraries(omnisci_server mapd_thrift thrift_handler ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${PROFILER_LIBS} ${ZLIB_LIBRARIES} ${LOCALE_LINK_FLAG} ${VT_LIBS})
 
 target_link_libraries(initdb mapd_thrift DataMgr ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${ZLIB_LIBRARIES})
 

--- a/MapDServer.cpp
+++ b/MapDServer.cpp
@@ -222,10 +222,10 @@ void run_warmup_queries(mapd::shared_ptr<DBHandler> handler,
         while (std::getline(query_file, single_query)) {
           boost::algorithm::trim(single_query);
           if (single_query.length() == 0 || single_query[0] == '-') {
-#if ENABLE_ITT          
-            if(single_query == "--itt_resume")
+#if ENABLE_ITT
+            if (single_query == "--itt_resume")
               __itt_resume();
-            else if(single_query == "--itt_pause")
+            else if (single_query == "--itt_pause")
               __itt_pause();
 #endif
             single_query.clear();
@@ -242,15 +242,16 @@ void run_warmup_queries(mapd::shared_ptr<DBHandler> handler,
           }
 
           try {
-#if ENABLE_ITT            
+#if ENABLE_ITT
             __itt_frame_begin_v3(ittquery, (__itt_id*)single_query.c_str());
 #endif
             g_warmup_handler->sql_execute(ret, sessionId, single_query, true, "", -1, -1);
 #if ENABLE_ITT
             __itt_frame_end_v3(ittquery, (__itt_id*)single_query.c_str());
 #endif
-          } catch (std::exception &e) {
-            LOG(WARNING) << "Exception " << e.what() << " while executing '" << single_query;
+          } catch (std::exception& e) {
+            LOG(WARNING) << "Exception " << e.what() << " while executing '"
+                         << single_query;
             stop = true;
             break;
           } catch (...) {
@@ -330,7 +331,6 @@ void heartbeat() {
 }
 
 int startMapdServer(CommandLineOptions& prog_config_opts, bool start_http_server = true) {
-
   // try to enforce an orderly shutdown even after a signal
   register_signal_handlers();
 

--- a/MapDServer.cpp
+++ b/MapDServer.cpp
@@ -61,6 +61,9 @@
 #include "Shared/file_delete.h"
 #include "Shared/mapd_shared_ptr.h"
 #include "Shared/scope.h"
+#if ENABLE_ITT
+#include <ittnotify.h>
+#endif
 
 using namespace ::apache::thrift;
 using namespace ::apache::thrift::concurrency;
@@ -177,6 +180,9 @@ void releaseWarmupSession(TSessionId& sessionId, std::ifstream& query_file) {
   }
 }
 
+#if ENABLE_ITT
+__itt_domain* ittquery = __itt_domain_create("Query");
+#endif
 void run_warmup_queries(mapd::shared_ptr<DBHandler> handler,
                         std::string base_path,
                         std::string query_file_path) {
@@ -196,7 +202,8 @@ void run_warmup_queries(mapd::shared_ptr<DBHandler> handler,
 
     ScopeGuard session_guard = [&] { releaseWarmupSession(sessionId, query_file); };
     query_file.open(query_file_path);
-    while (std::getline(query_file, db_info)) {
+    bool stop = false;
+    while (!stop && std::getline(query_file, db_info)) {
       if (db_info.length() == 0) {
         continue;
       }
@@ -215,6 +222,13 @@ void run_warmup_queries(mapd::shared_ptr<DBHandler> handler,
         while (std::getline(query_file, single_query)) {
           boost::algorithm::trim(single_query);
           if (single_query.length() == 0 || single_query[0] == '-') {
+#if ENABLE_ITT          
+            if(single_query == "--itt_resume")
+              __itt_resume();
+            else if(single_query == "--itt_pause")
+              __itt_pause();
+#endif
+            single_query.clear();
             continue;
           }
           if (single_query[0] == '}') {
@@ -228,14 +242,27 @@ void run_warmup_queries(mapd::shared_ptr<DBHandler> handler,
           }
 
           try {
+#if ENABLE_ITT            
+            __itt_frame_begin_v3(ittquery, (__itt_id*)single_query.c_str());
+#endif
             g_warmup_handler->sql_execute(ret, sessionId, single_query, true, "", -1, -1);
+#if ENABLE_ITT
+            __itt_frame_end_v3(ittquery, (__itt_id*)single_query.c_str());
+#endif
+          } catch (std::exception &e) {
+            LOG(WARNING) << "Exception " << e.what() << " while executing '" << single_query;
+            stop = true;
+            break;
           } catch (...) {
-            LOG(WARNING) << "Exception while executing '" << single_query
-                         << "', ignoring";
+            LOG(WARNING) << "Exception while executing '" << single_query << "'";
+            stop = true;
+            break;
           }
           single_query.clear();
         }
-
+#if ENABLE_ITT
+        __itt_detach();
+#endif
         // stop session and disconnect from the DB
         g_warmup_handler->disconnect(sessionId);
         sessionId = g_warmup_handler->getInvalidSessionId();
@@ -303,6 +330,7 @@ void heartbeat() {
 }
 
 int startMapdServer(CommandLineOptions& prog_config_opts, bool start_http_server = true) {
+
   // try to enforce an orderly shutdown even after a signal
   register_signal_handlers();
 

--- a/cmake/Modules/FindITTnotify.cmake
+++ b/cmake/Modules/FindITTnotify.cmake
@@ -1,0 +1,28 @@
+# Find ITTnotify ittnotify library
+# Defines:
+#   ITTnotify_FOUND
+#   ITTnotify_INCLUDE_DIRS
+#   ITTnotify_LIBRARIES
+set(dirs
+  "/opt/intel/vtune_profiler/"
+  "$ENV{VTUNE_PROFILER_2020_DIR}/"
+  "$ENV{VTUNE_PROFILER_2019_DIR}/"
+  "$ENV{VTUNE_AMPLIFIER_XE_2013_DIR}/"
+  "$ENV{VTUNE_AMPLIFIER_XE_2011_DIR}/"
+  "$ENV{CONDA_PREFIX}/"
+  )
+find_path(ITTnotify_INCLUDE_DIRS ittnotify.h
+    PATHS ${dirs}
+    PATH_SUFFIXES include)
+if (CMAKE_SIZEOF_VOID_P MATCHES "8")
+  set(vtune_lib_dir lib64)
+else()
+  set(vtune_lib_dir lib32)
+endif()
+find_library(ITTnotify_LIBRARIES ittnotify
+    HINTS "${ITTnotify_INCLUDE_DIRS}/.."
+    PATHS ${dirs}
+    PATH_SUFFIXES ${vtune_lib_dir})
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    ITTnotify DEFAULT_MSG ITTnotify_LIBRARIES ITTnotify_INCLUDE_DIRS)


### PR DESCRIPTION
VTune-enabled build. It is now possible to control the VTune traces via `--itt_pause` & `--itt_resume` in warmup queries