### PR TITLE
Shared execution context draft

### DIFF
--- a/QueryEngine/Descriptors/QueryMemoryDescriptor.cpp
+++ b/QueryEngine/Descriptors/QueryMemoryDescriptor.cpp
@@ -27,6 +27,7 @@
 
 bool g_enable_smem_group_by{true};
 extern bool g_enable_columnar_output;
+extern bool g_enable_cpu_shmem;
 
 namespace {
 
@@ -1077,6 +1078,11 @@ bool QueryMemoryDescriptor::usesGetGroupValueFast() const {
 
 bool QueryMemoryDescriptor::threadsShareMemory() const {
   return query_desc_type_ != QueryDescriptionType::NonGroupedAggregate;
+}
+
+bool QueryMemoryDescriptor::cpuThreadsShareMemory() const {
+  return g_enable_cpu_shmem &&
+         query_desc_type_ == QueryDescriptionType::GroupByPerfectHash && keyless_hash_;
 }
 
 bool QueryMemoryDescriptor::blocksShareMemory() const {

--- a/QueryEngine/Descriptors/QueryMemoryDescriptor.h
+++ b/QueryEngine/Descriptors/QueryMemoryDescriptor.h
@@ -296,6 +296,8 @@ class QueryMemoryDescriptor {
   bool blocksShareMemory() const;
   bool threadsShareMemory() const;
 
+  bool cpuThreadsShareMemory() const;
+
   bool lazyInitGroups(const ExecutorDeviceType) const;
 
   bool interleavedBins(const ExecutorDeviceType) const;

--- a/QueryEngine/Execute.cpp
+++ b/QueryEngine/Execute.cpp
@@ -138,6 +138,7 @@ size_t g_enable_parallel_linearization{
 
 size_t g_approx_quantile_buffer{1000};
 size_t g_approx_quantile_centroids{300};
+bool g_enable_cpu_shmem{false};
 
 bool g_enable_automatic_ir_metadata{true};
 
@@ -2294,6 +2295,11 @@ void Executor::launchKernels(SharedKernelContext& shared_context,
       }
       shared_context.addDeviceResults(std::move(results), {});
     }
+  }
+  if (shared_context.getSharedExecutionContext()) {
+    auto results = shared_context.getSharedExecutionContext()->getRowSet(
+        *ra_exe_unit, shared_context.getSharedExecutionContext()->query_mem_desc_);
+    shared_context.addDeviceResults(std::move(results), {});
   }
 }
 

--- a/QueryEngine/ExecutionKernel.h
+++ b/QueryEngine/ExecutionKernel.h
@@ -51,6 +51,14 @@ class SharedKernelContext {
   auto getThreadPool() { return thread_pool_; }
   void setThreadPool(threadpool::ThreadPool<void>* pool) { thread_pool_ = pool; }
   auto& getTlsExecutionContext() { return tls_execution_context_; }
+
+  void setSharedExecutionContext(std::unique_ptr<QueryExecutionContext> ctx) {
+    shared_execution_context_ = std::move(ctx);
+  }
+  QueryExecutionContext* getSharedExecutionContext() {
+    return shared_execution_context_.get();
+  }
+  std::mutex& getSharedExecutionContextMutex() { return shared_execution_context_mutex_; }
 #endif  // HAVE_TBB
 
  private:
@@ -66,6 +74,8 @@ class SharedKernelContext {
   threadpool::ThreadPool<void>* thread_pool_;
   tbb::enumerable_thread_specific<std::unique_ptr<QueryExecutionContext>>
       tls_execution_context_;
+  std::unique_ptr<QueryExecutionContext> shared_execution_context_;
+  std::mutex shared_execution_context_mutex_;
 #endif  // HAVE_TBB
 };
 

--- a/QueryEngine/RuntimeFunctions.cpp
+++ b/QueryEngine/RuntimeFunctions.cpp
@@ -311,6 +311,10 @@ extern "C" ALWAYS_INLINE uint64_t agg_count(uint64_t* agg, const int64_t) {
   return (*agg)++;
 }
 
+extern "C" ALWAYS_INLINE uint64_t agg_count_cpu_shared(uint64_t* agg, const int64_t) {
+  return __atomic_fetch_add(agg, (uint64_t)1, __ATOMIC_ACQ_REL);
+}
+
 extern "C" ALWAYS_INLINE void agg_count_distinct_bitmap(int64_t* agg,
                                                         const int64_t val,
                                                         const int64_t min_val) {
@@ -376,6 +380,10 @@ extern "C" ALWAYS_INLINE int64_t agg_sum(int64_t* agg, const int64_t val) {
   return old;
 }
 
+extern "C" ALWAYS_INLINE int64_t agg_sum_cpu_shared(int64_t* agg, const int64_t val) {
+  return __atomic_fetch_add(agg, val, __ATOMIC_ACQ_REL);
+}
+
 extern "C" ALWAYS_INLINE void agg_max(int64_t* agg, const int64_t val) {
   *agg = std::max(*agg, val);
 }
@@ -385,6 +393,10 @@ extern "C" ALWAYS_INLINE void agg_min(int64_t* agg, const int64_t val) {
 }
 
 extern "C" ALWAYS_INLINE void agg_id(int64_t* agg, const int64_t val) {
+  *agg = val;
+}
+
+extern "C" ALWAYS_INLINE void agg_id_cpu_shared(int64_t* agg, const int64_t val) {
   *agg = val;
 }
 

--- a/QueryEngine/RuntimeFunctions.cpp
+++ b/QueryEngine/RuntimeFunctions.cpp
@@ -388,8 +388,38 @@ extern "C" ALWAYS_INLINE void agg_max(int64_t* agg, const int64_t val) {
   *agg = std::max(*agg, val);
 }
 
+extern "C" ALWAYS_INLINE void agg_max_cpu_shared(int64_t* agg, const int64_t val) {
+  int64_t old_agg;
+  do {
+    __atomic_load(agg, &old_agg, __ATOMIC_ACQUIRE);
+    if (old_agg >= val) {
+      break;
+    }
+  } while (!__atomic_compare_exchange(agg,
+                                      &old_agg,
+                                      const_cast<int64_t*>(&val),
+                                      false,
+                                      __ATOMIC_ACQUIRE,
+                                      __ATOMIC_ACQ_REL));
+}
+
 extern "C" ALWAYS_INLINE void agg_min(int64_t* agg, const int64_t val) {
   *agg = std::min(*agg, val);
+}
+
+extern "C" ALWAYS_INLINE void agg_min_cpu_shared(int64_t* agg, const int64_t val) {
+  int64_t old_agg;
+  do {
+    __atomic_load(agg, &old_agg, __ATOMIC_ACQUIRE);
+    if (old_agg <= val) {
+      break;
+    }
+  } while (!__atomic_compare_exchange(agg,
+                                      &old_agg,
+                                      const_cast<int64_t*>(&val),
+                                      false,
+                                      __ATOMIC_ACQUIRE,
+                                      __ATOMIC_ACQ_REL));
 }
 
 extern "C" ALWAYS_INLINE void agg_id(int64_t* agg, const int64_t val) {
@@ -450,15 +480,41 @@ extern "C" ALWAYS_INLINE uint32_t agg_count_int32(uint32_t* agg, const int32_t) 
   return (*agg)++;
 }
 
+extern "C" ALWAYS_INLINE uint32_t agg_count_int32_cpu_shared(uint32_t* agg,
+                                                             const int32_t) {
+  return __atomic_fetch_add(agg, (uint32_t)1, __ATOMIC_ACQ_REL);
+}
+
 extern "C" ALWAYS_INLINE int32_t agg_sum_int32(int32_t* agg, const int32_t val) {
   const auto old = *agg;
   *agg += val;
   return old;
 }
 
+extern "C" ALWAYS_INLINE int32_t agg_sum_int32_cpu_shared(int32_t* agg,
+                                                          const int32_t val) {
+  return __atomic_fetch_add(agg, val, __ATOMIC_ACQ_REL);
+}
+
 #define DEF_AGG_MAX_INT(n)                                                              \
   extern "C" ALWAYS_INLINE void agg_max_int##n(int##n##_t* agg, const int##n##_t val) { \
     *agg = std::max(*agg, val);                                                         \
+  }                                                                                     \
+                                                                                        \
+  extern "C" ALWAYS_INLINE void agg_max_int##n##_cpu_shared(int##n##_t* agg,            \
+                                                            const int##n##_t val) {     \
+    int##n##_t old_agg;                                                                 \
+    do {                                                                                \
+      __atomic_load(agg, &old_agg, __ATOMIC_ACQUIRE);                                   \
+      if (old_agg >= val) {                                                             \
+        break;                                                                          \
+      }                                                                                 \
+    } while (!__atomic_compare_exchange(agg,                                            \
+                                        &old_agg,                                       \
+                                        const_cast<int##n##_t*>(&val),                  \
+                                        false,                                          \
+                                        __ATOMIC_ACQUIRE,                               \
+                                        __ATOMIC_ACQ_REL));                             \
   }
 
 DEF_AGG_MAX_INT(32)
@@ -469,6 +525,22 @@ DEF_AGG_MAX_INT(8)
 #define DEF_AGG_MIN_INT(n)                                                              \
   extern "C" ALWAYS_INLINE void agg_min_int##n(int##n##_t* agg, const int##n##_t val) { \
     *agg = std::min(*agg, val);                                                         \
+  }                                                                                     \
+                                                                                        \
+  extern "C" ALWAYS_INLINE void agg_min_int##n##_cpu_shared(int##n##_t* agg,            \
+                                                            const int##n##_t val) {     \
+    int##n##_t old_agg;                                                                 \
+    do {                                                                                \
+      __atomic_load(agg, &old_agg, __ATOMIC_ACQUIRE);                                   \
+      if (old_agg <= val) {                                                             \
+        break;                                                                          \
+      }                                                                                 \
+    } while (!__atomic_compare_exchange(agg,                                            \
+                                        &old_agg,                                       \
+                                        const_cast<int##n##_t*>(&val),                  \
+                                        false,                                          \
+                                        __ATOMIC_ACQUIRE,                               \
+                                        __ATOMIC_ACQ_REL));                             \
   }
 
 DEF_AGG_MIN_INT(32)
@@ -479,6 +551,11 @@ DEF_AGG_MIN_INT(8)
 #define DEF_AGG_ID_INT(n)                                                              \
   extern "C" ALWAYS_INLINE void agg_id_int##n(int##n##_t* agg, const int##n##_t val) { \
     *agg = val;                                                                        \
+  }                                                                                    \
+                                                                                       \
+  extern "C" ALWAYS_INLINE void agg_id_int##n##_cpu_shared(int##n##_t* agg,            \
+                                                           const int##n##_t val) {     \
+    __atomic_store(agg, const_cast<int##n##_t*>(&val), __ATOMIC_RELEASE);              \
   }
 
 #define DEF_CHECKED_SINGLE_AGG_ID_INT(n)                                  \
@@ -535,6 +612,26 @@ extern "C" ALWAYS_INLINE int64_t agg_sum_skip_val(int64_t* agg,
   return old;
 }
 
+extern "C" ALWAYS_INLINE int64_t agg_sum_skip_val_cpu_shared(int64_t* agg,
+                                                             const int64_t val,
+                                                             const int64_t skip_val) {
+  if (val != skip_val) {
+    if (__atomic_compare_exchange(agg,
+                                  const_cast<int64_t*>(&skip_val),
+                                  const_cast<int64_t*>(&val),
+                                  false,
+                                  __ATOMIC_ACQ_REL,
+                                  __ATOMIC_ACQUIRE)) {
+      return skip_val;
+    }
+
+    return agg_sum_cpu_shared(agg, val);
+  }
+  int64_t old;
+  __atomic_load(agg, &old, __ATOMIC_ACQUIRE);
+  return old;
+}
+
 extern "C" ALWAYS_INLINE int32_t agg_sum_int32_skip_val(int32_t* agg,
                                                         const int32_t val,
                                                         const int32_t skip_val) {
@@ -549,6 +646,27 @@ extern "C" ALWAYS_INLINE int32_t agg_sum_int32_skip_val(int32_t* agg,
   return old;
 }
 
+extern "C" ALWAYS_INLINE int32_t
+agg_sum_int32_skip_val_cpu_shared(int32_t* agg,
+                                  const int32_t val,
+                                  const int32_t skip_val) {
+  if (val != skip_val) {
+    if (__atomic_compare_exchange(agg,
+                                  const_cast<int32_t*>(&skip_val),
+                                  const_cast<int32_t*>(&val),
+                                  false,
+                                  __ATOMIC_ACQUIRE,
+                                  __ATOMIC_ACQ_REL)) {
+      return skip_val;
+    }
+
+    return agg_sum_int32_cpu_shared(agg, val);
+  }
+  int32_t old;
+  __atomic_load(agg, &old, __ATOMIC_ACQUIRE);
+  return old;
+}
+
 extern "C" ALWAYS_INLINE uint64_t agg_count_skip_val(uint64_t* agg,
                                                      const int64_t val,
                                                      const int64_t skip_val) {
@@ -556,6 +674,17 @@ extern "C" ALWAYS_INLINE uint64_t agg_count_skip_val(uint64_t* agg,
     return agg_count(agg, val);
   }
   return *agg;
+}
+
+extern "C" ALWAYS_INLINE uint64_t agg_count_skip_val_cpu_shared(uint64_t* agg,
+                                                                const int64_t val,
+                                                                const int64_t skip_val) {
+  if (val != skip_val) {
+    return agg_count_cpu_shared(agg, val);
+  }
+  int64_t old;
+  __atomic_load(reinterpret_cast<int64_t*>(agg), &old, __ATOMIC_ACQUIRE);
+  return old;
 }
 
 extern "C" ALWAYS_INLINE uint32_t agg_count_int32_skip_val(uint32_t* agg,
@@ -567,6 +696,18 @@ extern "C" ALWAYS_INLINE uint32_t agg_count_int32_skip_val(uint32_t* agg,
   return *agg;
 }
 
+extern "C" ALWAYS_INLINE uint32_t
+agg_count_int32_skip_val_cpu_shared(uint32_t* agg,
+                                    const int32_t val,
+                                    const int32_t skip_val) {
+  if (val != skip_val) {
+    return agg_count_int32_cpu_shared(agg, val);
+  }
+  int32_t old;
+  __atomic_load(reinterpret_cast<int32_t*>(agg), &old, __ATOMIC_ACQUIRE);
+  return old;
+}
+
 #define DEF_SKIP_AGG_ADD(base_agg_func)                       \
   extern "C" ALWAYS_INLINE void base_agg_func##_skip_val(     \
       DATA_T* agg, const DATA_T val, const DATA_T skip_val) { \
@@ -575,17 +716,31 @@ extern "C" ALWAYS_INLINE uint32_t agg_count_int32_skip_val(uint32_t* agg,
     }                                                         \
   }
 
-#define DEF_SKIP_AGG(base_agg_func)                           \
-  extern "C" ALWAYS_INLINE void base_agg_func##_skip_val(     \
-      DATA_T* agg, const DATA_T val, const DATA_T skip_val) { \
-    if (val != skip_val) {                                    \
-      const DATA_T old_agg = *agg;                            \
-      if (old_agg != skip_val) {                              \
-        base_agg_func(agg, val);                              \
-      } else {                                                \
-        *agg = val;                                           \
-      }                                                       \
-    }                                                         \
+#define DEF_SKIP_AGG(base_agg_func)                                  \
+  extern "C" ALWAYS_INLINE void base_agg_func##_skip_val(            \
+      DATA_T* agg, const DATA_T val, const DATA_T skip_val) {        \
+    if (val != skip_val) {                                           \
+      const DATA_T old_agg = *agg;                                   \
+      if (old_agg != skip_val) {                                     \
+        base_agg_func(agg, val);                                     \
+      } else {                                                       \
+        *agg = val;                                                  \
+      }                                                              \
+    }                                                                \
+  }                                                                  \
+                                                                     \
+  extern "C" ALWAYS_INLINE void base_agg_func##_skip_val_cpu_shared( \
+      DATA_T* agg, const DATA_T val, const DATA_T skip_val) {        \
+    if (val != skip_val) {                                           \
+      if (!__atomic_compare_exchange(agg,                            \
+                                     const_cast<DATA_T*>(&skip_val), \
+                                     const_cast<DATA_T*>(&val),      \
+                                     false,                          \
+                                     __ATOMIC_ACQ_REL,               \
+                                     __ATOMIC_ACQUIRE)) {            \
+        base_agg_func##_cpu_shared(agg, val);                        \
+      }                                                              \
+    }                                                                \
   }
 
 #define DATA_T int64_t
@@ -617,9 +772,28 @@ extern "C" ALWAYS_INLINE uint64_t agg_count_double(uint64_t* agg, const double v
   return (*agg)++;
 }
 
+extern "C" ALWAYS_INLINE uint64_t agg_count_double_cpu_shared(uint64_t* agg,
+                                                              const double val) {
+  return __atomic_fetch_add(agg, (uint64_t)1, __ATOMIC_ACQ_REL);
+}
+
 extern "C" ALWAYS_INLINE void agg_sum_double(int64_t* agg, const double val) {
   const auto r = *reinterpret_cast<const double*>(agg) + val;
   *agg = *reinterpret_cast<const int64_t*>(may_alias_ptr(&r));
+}
+
+extern "C" ALWAYS_INLINE void agg_sum_double_cpu_shared(int64_t* agg, const double val) {
+  double old_agg;
+  double new_agg;
+  do {
+    __atomic_load(reinterpret_cast<double*>(agg), &old_agg, __ATOMIC_ACQUIRE);
+    new_agg = old_agg + val;
+  } while (!__atomic_compare_exchange(agg,
+                                      reinterpret_cast<int64_t*>(&old_agg),
+                                      reinterpret_cast<int64_t*>(&new_agg),
+                                      false,
+                                      __ATOMIC_ACQUIRE,
+                                      __ATOMIC_ACQ_REL));
 }
 
 extern "C" ALWAYS_INLINE void agg_max_double(int64_t* agg, const double val) {
@@ -627,13 +801,51 @@ extern "C" ALWAYS_INLINE void agg_max_double(int64_t* agg, const double val) {
   *agg = *(reinterpret_cast<const int64_t*>(may_alias_ptr(&r)));
 }
 
+extern "C" ALWAYS_INLINE void agg_max_double_cpu_shared(int64_t* agg, const double val) {
+  double old_agg;
+  do {
+    __atomic_load(reinterpret_cast<double*>(agg), &old_agg, __ATOMIC_ACQUIRE);
+    if (old_agg >= val) {
+      break;
+    }
+  } while (
+      !__atomic_compare_exchange(agg,
+                                 reinterpret_cast<int64_t*>(&old_agg),
+                                 reinterpret_cast<int64_t*>(const_cast<double*>(&val)),
+                                 false,
+                                 __ATOMIC_ACQUIRE,
+                                 __ATOMIC_ACQ_REL));
+}
+
 extern "C" ALWAYS_INLINE void agg_min_double(int64_t* agg, const double val) {
   const auto r = std::min(*reinterpret_cast<const double*>(agg), val);
   *agg = *(reinterpret_cast<const int64_t*>(may_alias_ptr(&r)));
 }
 
+extern "C" ALWAYS_INLINE void agg_min_double_cpu_shared(int64_t* agg, const double val) {
+  double old_agg;
+  do {
+    __atomic_load(reinterpret_cast<double*>(agg), &old_agg, __ATOMIC_ACQUIRE);
+    if (old_agg <= val) {
+      break;
+    }
+  } while (
+      !__atomic_compare_exchange(agg,
+                                 reinterpret_cast<int64_t*>(&old_agg),
+                                 reinterpret_cast<int64_t*>(const_cast<double*>(&val)),
+                                 false,
+                                 __ATOMIC_ACQUIRE,
+                                 __ATOMIC_ACQ_REL));
+}
+
 extern "C" ALWAYS_INLINE void agg_id_double(int64_t* agg, const double val) {
   *agg = *(reinterpret_cast<const int64_t*>(may_alias_ptr(&val)));
+}
+
+extern "C" ALWAYS_INLINE void agg_id_double_cpu_shared(int64_t* agg, const double val) {
+  __atomic_store(agg,
+                 reinterpret_cast<int64_t*>(may_alias_ptr(const_cast<double*>(&val))),
+                 __ATOMIC_RELEASE);
 }
 
 extern "C" ALWAYS_INLINE int32_t checked_single_agg_id_double(int64_t* agg,
@@ -658,9 +870,28 @@ extern "C" ALWAYS_INLINE uint32_t agg_count_float(uint32_t* agg, const float val
   return (*agg)++;
 }
 
+extern "C" ALWAYS_INLINE uint32_t agg_count_float_cpu_shared(uint32_t* agg,
+                                                             const float val) {
+  return __atomic_fetch_add(agg, (uint32_t)1, __ATOMIC_ACQ_REL);
+}
+
 extern "C" ALWAYS_INLINE void agg_sum_float(int32_t* agg, const float val) {
   const auto r = *reinterpret_cast<const float*>(agg) + val;
   *agg = *reinterpret_cast<const int32_t*>(may_alias_ptr(&r));
+}
+
+extern "C" ALWAYS_INLINE void agg_sum_float_cpu_shared(int32_t* agg, const float val) {
+  float old_agg;
+  float new_agg;
+  do {
+    __atomic_load(reinterpret_cast<float*>(agg), &old_agg, __ATOMIC_ACQUIRE);
+    new_agg = old_agg + val;
+  } while (!__atomic_compare_exchange(agg,
+                                      reinterpret_cast<int32_t*>(&old_agg),
+                                      reinterpret_cast<int32_t*>(&new_agg),
+                                      false,
+                                      __ATOMIC_ACQUIRE,
+                                      __ATOMIC_ACQ_REL));
 }
 
 extern "C" ALWAYS_INLINE void agg_max_float(int32_t* agg, const float val) {
@@ -668,13 +899,51 @@ extern "C" ALWAYS_INLINE void agg_max_float(int32_t* agg, const float val) {
   *agg = *(reinterpret_cast<const int32_t*>(may_alias_ptr(&r)));
 }
 
+extern "C" ALWAYS_INLINE void agg_max_float_cpu_shared(int32_t* agg, const float val) {
+  float old_agg;
+  do {
+    __atomic_load(reinterpret_cast<float*>(agg), &old_agg, __ATOMIC_ACQUIRE);
+    if (old_agg >= val) {
+      break;
+    }
+  } while (
+      !__atomic_compare_exchange(agg,
+                                 reinterpret_cast<int32_t*>(&old_agg),
+                                 reinterpret_cast<int32_t*>(const_cast<float*>(&val)),
+                                 false,
+                                 __ATOMIC_ACQUIRE,
+                                 __ATOMIC_ACQ_REL));
+}
+
 extern "C" ALWAYS_INLINE void agg_min_float(int32_t* agg, const float val) {
   const auto r = std::min(*reinterpret_cast<const float*>(agg), val);
   *agg = *(reinterpret_cast<const int32_t*>(may_alias_ptr(&r)));
 }
 
+extern "C" ALWAYS_INLINE void agg_min_float_cpu_shared(int32_t* agg, const float val) {
+  float old_agg;
+  do {
+    __atomic_load(reinterpret_cast<float*>(agg), &old_agg, __ATOMIC_ACQUIRE);
+    if (old_agg <= val) {
+      break;
+    }
+  } while (
+      !__atomic_compare_exchange(agg,
+                                 reinterpret_cast<int32_t*>(&old_agg),
+                                 reinterpret_cast<int32_t*>(const_cast<float*>(&val)),
+                                 false,
+                                 __ATOMIC_ACQUIRE,
+                                 __ATOMIC_ACQ_REL));
+}
+
 extern "C" ALWAYS_INLINE void agg_id_float(int32_t* agg, const float val) {
   *agg = *(reinterpret_cast<const int32_t*>(may_alias_ptr(&val)));
+}
+
+extern "C" ALWAYS_INLINE void agg_id_float_cpu_shared(int32_t* agg, const float val) {
+  __atomic_store(agg,
+                 reinterpret_cast<int32_t*>(may_alias_ptr(const_cast<float*>(&val))),
+                 __ATOMIC_RELEASE);
 }
 
 extern "C" ALWAYS_INLINE int32_t checked_single_agg_id_float(int32_t* agg,
@@ -704,6 +973,18 @@ extern "C" ALWAYS_INLINE uint64_t agg_count_double_skip_val(uint64_t* agg,
   return *agg;
 }
 
+extern "C" ALWAYS_INLINE uint64_t
+agg_count_double_skip_val_cpu_shared(uint64_t* agg,
+                                     const double val,
+                                     const double skip_val) {
+  if (val != skip_val) {
+    return agg_count_double_cpu_shared(agg, val);
+  }
+  uint64_t old;
+  __atomic_load(agg, &old, __ATOMIC_ACQUIRE);
+  return old;
+}
+
 extern "C" ALWAYS_INLINE uint32_t agg_count_float_skip_val(uint32_t* agg,
                                                            const float val,
                                                            const float skip_val) {
@@ -713,25 +994,59 @@ extern "C" ALWAYS_INLINE uint32_t agg_count_float_skip_val(uint32_t* agg,
   return *agg;
 }
 
-#define DEF_SKIP_AGG_ADD(base_agg_func)                       \
-  extern "C" ALWAYS_INLINE void base_agg_func##_skip_val(     \
-      ADDR_T* agg, const DATA_T val, const DATA_T skip_val) { \
-    if (val != skip_val) {                                    \
-      base_agg_func(agg, val);                                \
-    }                                                         \
+extern "C" ALWAYS_INLINE uint32_t
+agg_count_float_skip_val_cpu_shared(uint32_t* agg,
+                                    const float val,
+                                    const float skip_val) {
+  if (val != skip_val) {
+    return agg_count_float_cpu_shared(agg, val);
+  }
+  uint32_t old;
+  __atomic_load(agg, &old, __ATOMIC_ACQUIRE);
+  return old;
+}
+
+#define DEF_SKIP_AGG_ADD(base_agg_func)                              \
+  extern "C" ALWAYS_INLINE void base_agg_func##_skip_val(            \
+      ADDR_T* agg, const DATA_T val, const DATA_T skip_val) {        \
+    if (val != skip_val) {                                           \
+      base_agg_func(agg, val);                                       \
+    }                                                                \
+  }                                                                  \
+                                                                     \
+  extern "C" ALWAYS_INLINE void base_agg_func##_skip_val_cpu_shared( \
+      ADDR_T* agg, const DATA_T val, const DATA_T skip_val) {        \
+    if (val != skip_val) {                                           \
+      base_agg_func##_cpu_shared(agg, val);                          \
+    }                                                                \
   }
 
-#define DEF_SKIP_AGG(base_agg_func)                                                \
-  extern "C" ALWAYS_INLINE void base_agg_func##_skip_val(                          \
-      ADDR_T* agg, const DATA_T val, const DATA_T skip_val) {                      \
-    if (val != skip_val) {                                                         \
-      const ADDR_T old_agg = *agg;                                                 \
-      if (old_agg != *reinterpret_cast<const ADDR_T*>(may_alias_ptr(&skip_val))) { \
-        base_agg_func(agg, val);                                                   \
-      } else {                                                                     \
-        *agg = *reinterpret_cast<const ADDR_T*>(may_alias_ptr(&val));              \
-      }                                                                            \
-    }                                                                              \
+#define DEF_SKIP_AGG(base_agg_func)                                                     \
+  extern "C" ALWAYS_INLINE void base_agg_func##_skip_val(                               \
+      ADDR_T* agg, const DATA_T val, const DATA_T skip_val) {                           \
+    if (val != skip_val) {                                                              \
+      const ADDR_T old_agg = *agg;                                                      \
+      if (old_agg != *reinterpret_cast<const ADDR_T*>(may_alias_ptr(&skip_val))) {      \
+        base_agg_func(agg, val);                                                        \
+      } else {                                                                          \
+        *agg = *reinterpret_cast<const ADDR_T*>(may_alias_ptr(&val));                   \
+      }                                                                                 \
+    }                                                                                   \
+  }                                                                                     \
+                                                                                        \
+  extern "C" ALWAYS_INLINE void base_agg_func##_skip_val_cpu_shared(                    \
+      ADDR_T* agg, const DATA_T val, const DATA_T skip_val) {                           \
+    if (val != skip_val) {                                                              \
+      if (!__atomic_compare_exchange(                                                   \
+              agg,                                                                      \
+              reinterpret_cast<ADDR_T*>(may_alias_ptr(const_cast<DATA_T*>(&skip_val))), \
+              reinterpret_cast<ADDR_T*>(may_alias_ptr(const_cast<DATA_T*>(&val))),      \
+              false,                                                                    \
+              __ATOMIC_ACQ_REL,                                                         \
+              __ATOMIC_ACQUIRE)) {                                                      \
+        base_agg_func##_cpu_shared(agg, val);                                           \
+      }                                                                                 \
+    }                                                                                   \
   }
 
 #define DATA_T double

--- a/QueryEngine/RuntimeFunctions.h
+++ b/QueryEngine/RuntimeFunctions.h
@@ -46,6 +46,9 @@ extern "C" int32_t agg_sum_int32_skip_val(int32_t* agg,
 extern "C" int64_t agg_sum_skip_val(int64_t* agg,
                                     const int64_t val,
                                     const int64_t skip_val);
+extern "C" int64_t agg_sum_skip_val_cpu_shared(int64_t* agg,
+                                               const int64_t val,
+                                               const int64_t skip_val);
 
 extern "C" void agg_max_skip_val(int64_t* agg, const int64_t val, const int64_t skip_val);
 
@@ -68,6 +71,7 @@ extern "C" void agg_min_double_skip_val(int64_t* agg,
                                         const double skip_val);
 
 extern "C" int32_t agg_sum_int32(int32_t* agg, const int32_t val);
+extern "C" int32_t agg_sum_int32_cpu_shared(int32_t* agg, const int32_t val);
 
 extern "C" void agg_max_int32(int32_t* agg, const int32_t val);
 extern "C" void agg_max_int16(int16_t* agg, const int16_t val);

--- a/QueryEngine/RuntimeFunctions.h
+++ b/QueryEngine/RuntimeFunctions.h
@@ -27,6 +27,8 @@
 
 extern "C" int64_t agg_sum(int64_t* agg, const int64_t val);
 
+extern "C" int64_t agg_sum_cpu_shared(int64_t* agg, const int64_t val);
+
 extern "C" void agg_max(int64_t* agg, const int64_t val);
 
 extern "C" void agg_min(int64_t* agg, const int64_t val);

--- a/QueryEngine/TargetExprBuilder.cpp
+++ b/QueryEngine/TargetExprBuilder.cpp
@@ -544,6 +544,9 @@ void TargetExprCodegen::codegenAggregate(
           if (needs_unnest_double_patch) {
             agg_fname = patch_agg_fname(agg_fname);
           }
+        } else if (co.device_type == ExecutorDeviceType::CPU &&
+                   query_mem_desc.cpuThreadsShareMemory()) {
+          agg_fname += "_cpu_shared";
         }
         auto agg_fname_call_ret_lv = group_by_and_agg->emitCall(agg_fname, agg_args);
 

--- a/ThriftHandler/CommandLineOptions.cpp
+++ b/ThriftHandler/CommandLineOptions.cpp
@@ -782,6 +782,11 @@ void CommandLineOptions::fillAdvancedOptions() {
           ->default_value(g_allow_query_step_cpu_retry)
           ->implicit_value(true),
       R"(Allow certain query steps to retry on CPU, even when allow-cpu-retry is disabled)");
+  developer_desc.add_options()("enable-cpu-shmem",
+                               po::value<bool>(&g_enable_cpu_shmem)
+                                   ->default_value(g_enable_cpu_shmem)
+                                   ->implicit_value(true),
+                               "Enable shared execution context for CPU code.");
 }
 
 namespace {

--- a/ThriftHandler/CommandLineOptions.h
+++ b/ThriftHandler/CommandLineOptions.h
@@ -205,3 +205,4 @@ extern float g_vacuum_min_selectivity;
 extern bool g_read_only;
 extern bool g_enable_automatic_ir_metadata;
 extern size_t g_enable_parallel_linearization;
+extern bool g_enable_cpu_shmem;


### PR DESCRIPTION
A shared execution context is used to reduce initialization and reduction costs. The feature is in a draft state, works only for a keyless perfect hash with COUNT and SUM aggregates. Works with sub-fragments only.