### PR TITLE
Return empty record batch instead of nullptr for empty results.

### DIFF
--- a/Embedded/DBEngine.cpp
+++ b/Embedded/DBEngine.cpp
@@ -73,17 +73,10 @@ class CursorImpl : public Cursor {
     if (record_batch_) {
       return record_batch_;
     }
-    auto col_count = getColCount();
-    if (col_count > 0) {
-      auto row_count = getRowCount();
-      if (row_count > 0) {
-        auto converter =
-            std::make_unique<ArrowResultSetConverter>(result_set_, col_names_, -1);
-        record_batch_ = converter->convertToArrow();
-        return record_batch_;
-      }
-    }
-    return nullptr;
+    auto converter =
+        std::make_unique<ArrowResultSetConverter>(result_set_, col_names_, -1);
+    record_batch_ = converter->convertToArrow();
+    return record_batch_;
   }
 
  private:

--- a/QueryEngine/ArrowResultSetConverter.cpp
+++ b/QueryEngine/ArrowResultSetConverter.cpp
@@ -635,6 +635,9 @@ std::shared_ptr<arrow::RecordBatch> ArrowResultSetConverter::getArrowBatch(
   // If so, we return an arrow result set that only
   // contains the schema (no record batch will be serialized).
   if (results_->isEmpty()) {
+    for (auto& field : schema->fields()) {
+      result_columns.push_back(arrow::MakeArrayOfNull(field->type(), 0).ValueOrDie());
+    }
     return ARROW_RECORDBATCH_MAKE(schema, 0, result_columns);
   }
 


### PR DESCRIPTION
Don't return nullptr for empty results and fix empty record batch to make it suitable for Arrow Table construction.
