### PR TITLE
Update system dynamically when new license is set.

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -637,8 +637,7 @@ endif()
 ##########
 
 add_executable(SessionsStoreTest SessionsStoreTest.cpp)
-target_link_libraries(SessionsStoreTest gtest Catalog ${Boost_LIBRARIES}
-  ${MAPD_LIBRARIES} ${CUDA_LIBRARIES} ${AwsS3_CURL_SUPPORT})
+target_link_libraries(SessionsStoreTest ${THRIFT_HANDLER_TEST_LIBRARIES})
 add_test(SessionsStoreTest SessionsStoreTest ${TEST_ARGS})
 list(APPEND SANITY_TEST_PROGRAMS SessionsStoreTest)
 
@@ -673,6 +672,7 @@ if(NOT MSVC)
   add_dependencies(LoadBalancerTest thrift_gen)
   add_dependencies(LoadBalancerTest heavydb) # test invokes heavydb bin directly
   add_dependencies(LoadBalancerTest mapd_java_components)
+  add_test(LoadBalancerTest, LoadBalancerTest ${TEST_ARGS})
 endif()
 
 ##########

--- a/Tests/DBHandlerTestHelpers.h
+++ b/Tests/DBHandlerTestHelpers.h
@@ -772,15 +772,6 @@ class DBHandlerTestFixture : public testing::Test {
     }
   }
 
-  static void setupSignalHandler() {
-    TestProcessSignalHandler::registerSignalHandler();
-    TestProcessSignalHandler::addShutdownCallback([]() {
-      if (db_handler_) {
-        db_handler_->shutdown();
-      }
-    });
-  }
-
   static std::unique_ptr<DBHandler> db_handler_;
   static TSessionId session_id_;
   static TSessionId admin_session_id_;
@@ -792,13 +783,23 @@ class DBHandlerTestFixture : public testing::Test {
   static std::string udf_compiler_path_;
   static std::string default_user_;
   static std::string default_pass_;
-  static std::string default_db_name_;
   static std::vector<std::string> udf_compiler_options_;
 #ifdef ENABLE_GEOS
   static std::string libgeos_so_filename_;
 #endif
 
  public:
+  static void setupSignalHandler() {
+    TestProcessSignalHandler::registerSignalHandler();
+    TestProcessSignalHandler::addShutdownCallback([]() {
+      if (db_handler_) {
+        db_handler_->shutdown();
+      }
+    });
+  }
+
+  static std::string default_db_name_;
+
   static std::string cluster_config_file_path_;
   static File_Namespace::DiskCacheLevel disk_cache_level_;
 };

--- a/Tests/LoadBalancerTest.cpp
+++ b/Tests/LoadBalancerTest.cpp
@@ -31,6 +31,14 @@
 #include "gen-cpp/Heavy.h"
 
 std::filesystem::path binary_path;
+// This is an odd hack that is needed because the Go compiler has some issues with our C++
+// program linking a Go library compiled from a C++ file containg C functions.  This gets
+// overwritten later in linking, but we need a default definition to avoid a linking
+// error.
+extern "C" void etcd_onMemberUpdate_thunk(void* self,
+                                          char* member_name,
+                                          char* hostip_cstr,
+                                          int port) {}
 
 using namespace apache::thrift::protocol;
 namespace bp = boost::process;
@@ -92,6 +100,7 @@ struct Connection {
         std::cout << "connected to server on port " << port << "\n";
         break;
       } catch (...) {
+        std::this_thread::sleep_for(1'000ms);
         // Keep trying to connect until we are successful.
       }
     }

--- a/Tests/SessionsStoreTest.cpp
+++ b/Tests/SessionsStoreTest.cpp
@@ -30,6 +30,7 @@
 #include "Catalog/SysCatalog.h"
 #include "CudaMgr/CudaMgr.h"
 #include "Shared/StringTransform.h"
+#include "Tests/DBHandlerTestHelpers.h"
 #include "Tests/TestHelpers.h"
 
 #ifndef BASE_PATH

--- a/ThriftHandler/DBHandler.h
+++ b/ThriftHandler/DBHandler.h
@@ -943,7 +943,6 @@ class DBHandler : public HeavyIf {
       bool assign_render_groups);
 
   query_state::QueryStates query_states_;
-  std::unique_ptr<Catalog_Namespace::SessionsStore> sessions_store_;
   std::unordered_map<std::string, Catalog_Namespace::SessionInfoPtr> calcite_sessions_;
   mutable heavyai::shared_mutex calcite_sessions_mtx_;
 
@@ -974,6 +973,8 @@ class DBHandler : public HeavyIf {
   const std::string& udf_filename_;
   const std::string& clang_path_;
   const std::vector<std::string>& clang_options_;
+  int32_t max_num_sessions_{-1};
+  std::unique_ptr<Catalog_Namespace::SessionsStore> sessions_store_;
 
   struct DeferredCopyFromState {
     std::string table;
@@ -1096,4 +1097,6 @@ class DBHandler : public HeavyIf {
                             const import_export::CopyParams& copy_params,
                             const TRowDescriptor& row_desc,
                             const TCreateParams& create_params);
+
+  void resetSessionsStore();
 };


### PR DESCRIPTION
This PR fixes a few issues:

Fixes persistence of num sessions.
Currently there is no distinction between the number of sessions specified by the command line and the number of sessions persisted between restarts, so we had no way of telling if the restarted value came from a cmd line parameter or a previous license and which should take priority. This is fixed by creating a new record of the number of sessions in the DBhandler so that we have a distinction between the current value, the cmd-line value, and the license value.


Signed-off-by: jack <jack@omnisci.com>