### PR TITLE
Update QueryExporterGDAL.cpp

### DIFF
--- a/ImportExport/QueryExporterGDAL.cpp
+++ b/ImportExport/QueryExporterGDAL.cpp
@@ -115,7 +115,7 @@ OGRFieldType sql_type_info_to_ogr_field_type(const std::string& name,
     case kTIME:
     case kTIMESTAMP:
     case kDATE:
-      return OFTString;
+      return OFTDate;
     case kBIGINT:
     case kINTERVAL_DAY_TIME:
     case kINTERVAL_YEAR_MONTH:


### PR DESCRIPTION
Change export type of kDATE in a shape file to OFTDate in OGR/GDAL types.

From docs:
"In GDAL OGR, the type used for dates is OFTDate. This corresponds to a date field that stores only the year, month, and day, without any time or timezone information."